### PR TITLE
1.0.6.qivicon

### DIFF
--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>californium-core</artifactId>
 	<packaging>bundle</packaging>

--- a/californium-core/pom.xml
+++ b/californium-core/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>californium-core</artifactId>
 	<packaging>bundle</packaging>

--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>californium-osgi</artifactId>
 	<packaging>bundle</packaging>

--- a/californium-osgi/pom.xml
+++ b/californium-osgi/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>californium-osgi</artifactId>
 	<packaging>bundle</packaging>
@@ -17,7 +17,7 @@
 	<description>OSGi wrapper</description>
 
 	<properties>
-		<osgi.version>4.3.1</osgi.version>
+		<osgi.version>4.2.0</osgi.version>
 	</properties>
 	
 	<dependencies>

--- a/californium-osgi/src/test/java/org/eclipse/californium/osgi/ManagedServerTest.java
+++ b/californium-osgi/src/test/java/org/eclipse/californium/osgi/ManagedServerTest.java
@@ -138,7 +138,7 @@ public class ManagedServerTest {
 	@Test
 	public void testAddingService() throws Exception {
 		Resource resource = new CoapResource("test");
-		ServiceReference<Resource> ref = mock(ServiceReference.class);
+		ServiceReference ref = mock(ServiceReference.class);
 		when(bundleContext.getService(ref)).thenReturn(resource);
 		managedServer.updated(null);
 		
@@ -151,7 +151,7 @@ public class ManagedServerTest {
 	@Test
 	public void testRemovedService() throws Exception {
 		Resource resource = new CoapResource("test");
-		ServiceReference<Resource> ref = mock(ServiceReference.class);
+		ServiceReference ref = mock(ServiceReference.class);
 		when(bundleContext.getService(ref)).thenReturn(resource);
 		managedServer.updated(null);
 		

--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>californium-proxy</artifactId>
 	<packaging>bundle</packaging>

--- a/californium-proxy/pom.xml
+++ b/californium-proxy/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>californium-proxy</artifactId>
 	<packaging>bundle</packaging>

--- a/demo-apps/cf-benchmark-observe/pom.xml
+++ b/demo-apps/cf-benchmark-observe/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-benchmark-observe</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-benchmark-observe/pom.xml
+++ b/demo-apps/cf-benchmark-observe/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-benchmark-observe</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-benchmark/pom.xml
+++ b/demo-apps/cf-benchmark/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-benchmark</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-benchmark/pom.xml
+++ b/demo-apps/cf-benchmark/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-benchmark</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-cocoa/pom.xml
+++ b/demo-apps/cf-cocoa/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-cocoa</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-cocoa/pom.xml
+++ b/demo-apps/cf-cocoa/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-cocoa</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-helloworld-client/pom.xml
+++ b/demo-apps/cf-helloworld-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-helloworld-client</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-helloworld-client/pom.xml
+++ b/demo-apps/cf-helloworld-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-helloworld-client</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-helloworld-server/pom.xml
+++ b/demo-apps/cf-helloworld-server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-helloworld-server</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-helloworld-server/pom.xml
+++ b/demo-apps/cf-helloworld-server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-helloworld-server</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-plugtest-checker/pom.xml
+++ b/demo-apps/cf-plugtest-checker/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-plugtest-checker</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-plugtest-checker/pom.xml
+++ b/demo-apps/cf-plugtest-checker/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-plugtest-checker</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-plugtest-client/pom.xml
+++ b/demo-apps/cf-plugtest-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-plugtest-client</artifactId>
 

--- a/demo-apps/cf-plugtest-client/pom.xml
+++ b/demo-apps/cf-plugtest-client/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-plugtest-client</artifactId>
 

--- a/demo-apps/cf-plugtest-server/pom.xml
+++ b/demo-apps/cf-plugtest-server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-plugtest-server</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-plugtest-server/pom.xml
+++ b/demo-apps/cf-plugtest-server/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-plugtest-server</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-proxy/pom.xml
+++ b/demo-apps/cf-proxy/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-proxy</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-proxy/pom.xml
+++ b/demo-apps/cf-proxy/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-proxy</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-secure/pom.xml
+++ b/demo-apps/cf-secure/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>cf-secure</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/cf-secure/pom.xml
+++ b/demo-apps/cf-secure/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>cf-secure</artifactId>
 	<packaging>jar</packaging>

--- a/demo-apps/pom.xml
+++ b/demo-apps/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>demo-apps</artifactId>
 	<packaging>pom</packaging>

--- a/demo-apps/pom.xml
+++ b/demo-apps/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>demo-apps</artifactId>
 	<packaging>pom</packaging>

--- a/demo-apps/sc-dtls-example/pom.xml
+++ b/demo-apps/sc-dtls-example/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>sc-dtls-example</artifactId>
 

--- a/demo-apps/sc-dtls-example/pom.xml
+++ b/demo-apps/sc-dtls-example/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>demo-apps</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>sc-dtls-example</artifactId>
 

--- a/demo-certs/pom.xml
+++ b/demo-certs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>demo-certs</artifactId>
 

--- a/demo-certs/pom.xml
+++ b/demo-certs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>demo-certs</artifactId>
 

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>element-connector</artifactId>

--- a/element-connector/pom.xml
+++ b/element-connector/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 
 	<artifactId>element-connector</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.eclipse.californium</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.0.7-SNAPSHOT</version>
+	<version>1.0.6.QIVICON-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Californium (Cf) Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
 	<groupId>org.eclipse.californium</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.0.6.QIVICON-SNAPSHOT</version>
+	<version>1.0.6.QIVICON</version>
 	<packaging>pom</packaging>
 
 	<name>Californium (Cf) Parent</name>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.7-SNAPSHOT</version>
+		<version>1.0.6.QIVICON-SNAPSHOT</version>
 	</parent>
 	<artifactId>scandium</artifactId>
 	<packaging>bundle</packaging>

--- a/scandium-core/pom.xml
+++ b/scandium-core/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.eclipse.californium</groupId>
 		<artifactId>parent</artifactId>
-		<version>1.0.6.QIVICON-SNAPSHOT</version>
+		<version>1.0.6.QIVICON</version>
 	</parent>
 	<artifactId>scandium</artifactId>
 	<packaging>bundle</packaging>


### PR DESCRIPTION
Californium Release 1.0.6.QIVICON -
--  based on Californium 1.0.6 release + bug fix. 
--  Ported to support OSGI 4.2
